### PR TITLE
Update docs: cursor.edit -> cursor.set

### DIFF
--- a/README.md
+++ b/README.md
@@ -606,10 +606,10 @@ var Input = React.createClass({
     var newValue = e.target.value;
 
     // If one edits the tree normally, i.e. asynchronously, the cursor will hop
-    this.cursor.edit(newValue);
+    this.cursor.set(newValue);
 
     // One has to commit synchronously the update for the input to work correctly
-    this.cursor.edit(newValue);
+    this.cursor.set(newValue);
     this.tree.commit();
   },
   render: function() {


### PR DESCRIPTION
Hello! It looks like the docs needed to be updated to the 1.x syntax. (`cursor.edit` -> `cursor.set`).