### PR TITLE
handleChildRef

### DIFF
--- a/src/higher-order.js
+++ b/src/higher-order.js
@@ -76,6 +76,14 @@ export function branch(Component, mapping=null) {
       } : {};
     }
 
+    getDecoratedComponentInstance() {
+	return this.decoratedComponentInstance
+    }
+
+    handleChildRef(component) {
+	this.decoratedComponentInstance = component
+    }
+
     // Building initial state
     constructor(props, context) {
       super(props, context);
@@ -123,7 +131,7 @@ export function branch(Component, mapping=null) {
         });
       }
 
-      return <Component {...this.props} {...suppl} {...this.state} />;
+      return <Component {...this.props} {...suppl} {...this.state} ref={this.handleChildRef.bind(this)} />;
     }
 
     // On component unmount


### PR DESCRIPTION
Sometimes it is helpful to be able to have a ref for the components that are wrapped. I use this instance method quite a bit. This same convention appears in react-dnd and I'd like to see if its possible to include in this library. 

Open to any other suggestions!