### PR TITLE
Fixed curry function.

### DIFF
--- a/src/utils/helpers.js
+++ b/src/utils/helpers.js
@@ -8,14 +8,16 @@
 /**
  * Simple curry function.
  */
-export function curry(fn, arity, acc) {
-  acc = acc || [];
-
-  return function(...args) {
-    if (args.length < arity)
-      return curry(fn, arity - 1, acc.concat(args));
-
-    return fn(...args);
+export function curry(fn, arity) {
+  return function f1(...args) {
+    if (args.length >= arity) {
+      return fn.apply(null, args);
+    }
+    else {
+      return function f2(...args2) {
+        return f1.apply(null, args.concat(args2));
+      };
+    }
   };
 }
 

--- a/test/higher-order.jsx
+++ b/test/higher-order.jsx
@@ -41,6 +41,18 @@ describe('Higher Order', function() {
 
       assert(typeof rootTest === 'function');
       assert(typeof branchTest === 'function');
+
+      const rootWithComponentTest = root(new Baobab(), DummyRoot),
+            branchWithComponentTest = branch({}, DummyRoot);
+
+      assert(typeof rootWithComponentTest === 'function');
+      assert(typeof branchWithComponentTest === 'function');
+
+      const rootThenComponentTest = root(new Baobab())(DummyRoot),
+            branchThenComponentTest = branch({})(DummyRoot);
+
+      assert(typeof rootThenComponentTest === 'function');
+      assert(typeof branchThenComponentTest === 'function');
     });
 
     it('root should throw an error if the passed argument is not a tree.', function() {


### PR DESCRIPTION
This is a fix for issue #109, as I'm having the same problem.
The curry function is not currently doing its job.

This works: `branch({}, Component)`
This does not: `branch({})(Component)`

The latter is necessary in order to use as a decorator. I replaced the curry function with my own working version and updated the tests to reflect that scenario.