### PR TITLE
[Breaking] Higher-Order: Implemented new ref handling to fix React >= 16 warnings

### DIFF
--- a/docs/higher-order.md
+++ b/docs/higher-order.md
@@ -12,6 +12,7 @@ In this example, we'll build a simplistic React app showing a list of colors to 
 * [Accessing the tree and cursors](#accessing-the-tree-and-cursors)
 * [Clever vs. dumb components](#clever-vs-dumb-components)
 * [Currying & Decorators](#currying-decorators)
+* [Dealing with refs to your wrapped components](#dealing-with-refs)
 
 ### Creating the app's state
 
@@ -359,6 +360,39 @@ This also means you can use them as ES7 decorators:
 class Greeting extends Component {
   render() {
     return <span>Hello {this.props.name}!</span>;
+  }
+}
+```
+
+<h3 id="dealing-with-refs">Dealing with refs to your wrapped components</h3>
+
+When wrapping a component with a higher-order component, a new component is created around the component you pass to the HOC.
+
+Due to this, when setting a `ref` prop on the decorated component, the reference will point to the wrapping component's instance, instead of pointing to the wrapped component as you probably intend to do.
+
+To solve this problem, the decorated component takes a `decoratedComponentRef` prop which is then forwarded to the wrapped component as a usual `ref` prop.
+
+In other words, if you want to obtain a ref to your wrapped component, you can do so like this:
+
+In your jsx:
+
+```js
+
+class Greeting extends Component {
+  render() {
+    return <span>Hello {this.props.name}!</span>;
+  }
+}
+
+const BranchGreeting = branch({name: ['name']}, Greeting);
+
+class App extends Component {
+  setRef (instance) {
+    // instance will now point to the rendered instance of Greeting
+  }
+
+  render() {
+    return <BranchGreeting decoratedComponentRef={this.setRef}/>;
   }
 }
 ```

--- a/src/higher-order.js
+++ b/src/higher-order.js
@@ -78,14 +78,6 @@ function branch(cursors, Component) {
 
   const ComposedComponent = class extends React.Component {
 
-    getDecoratedComponentInstance() {
-        return this.decoratedComponentInstance;
-    }
-
-    handleChildRef(component) {
-        this.decoratedComponentInstance = component;
-    }
-
     // Building initial state
     constructor(props, context) {
       super(props, context);
@@ -123,9 +115,10 @@ function branch(cursors, Component) {
 
     // Render shim
     render() {
+      const {decoratedComponentRef, ...props} = {this.props};
       const suppl = {dispatch: this.dispatcher};
 
-      return <Component {...this.props} {...suppl} {...this.state} ref={this.handleChildRef.bind(this)} />;
+      return <Component {...props} {...suppl} {...this.state} ref={decoratedComponentRef} />;
     }
 
     // On component unmount

--- a/src/higher-order.js
+++ b/src/higher-order.js
@@ -115,7 +115,7 @@ function branch(cursors, Component) {
 
     // Render shim
     render() {
-      const {decoratedComponentRef, ...props} = {this.props};
+      const {decoratedComponentRef, ...props} = this.props;
       const suppl = {dispatch: this.dispatcher};
 
       return <Component {...props} {...suppl} {...this.state} ref={decoratedComponentRef} />;

--- a/test/higher-order.jsx
+++ b/test/higher-order.jsx
@@ -227,7 +227,7 @@ describe('Higher Order', function() {
       }, 50);
     });
 
-    it('wrapper component should return wrapping component instance by getDecoratedComponentInstance.', function() {
+    it('wrapper component should allow setting a ref on the wrapped component using the decoratedComponentRef prop.', function(done) {
       const tree = new Baobab({counter: 0}, {asynchronous: false});
 
       class Counter extends Component {
@@ -244,10 +244,12 @@ describe('Higher Order', function() {
 
       const BranchedCounter = branch({counter: 'counter'}, Counter);
 
-      const wrapper = mount(<Root tree={tree}><BranchedCounter /></Root>);
-      const decoratedComponentInstance = wrapper.find(BranchedCounter).get(0).getDecoratedComponentInstance();
+      const wrapper = mount(<Root tree={tree}><BranchedCounter decoratedComponentRef={checkIfNodeIsCounter} /></Root>);
 
-      assert(decoratedComponentInstance instanceof Counter);
+      function checkIfNodeIsCounter(instance) {
+        assert(instance instanceof Counter);
+        done();
+      }
     });
   });
 


### PR DESCRIPTION
Previously, refs on the wrapped component's instances were created for each branched  component. The refs could then be accessed using the `ComposedComponent`'s `getDecoratedComponentInstance` method. However, this implementation also assigned refs to Stateless Functional Components (SFCs), which is not supported by React and leads to console warnings by React from version 16 and upwards.

The previous behavior has been replaced, removing the `getDecoratedComponentInstance` method from the `ComposedComponent` class, making this a **breaking change**.

The new implementation takes a new prop `decoratedComponentRef` and assigns this to the `ref` of the wrapped component.