### PR TITLE
React 17 context API & hook

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,7 @@ npm run build
 # or per pattern
 npm run build-mixins
 npm run build-higher-order
+npm run build-hooks
 ```
 
 ## License

--- a/README.md
+++ b/README.md
@@ -6,8 +6,9 @@ Welcome to [baobab](https://github.com/Yomguithereal/baobab)'s [React](https://f
 
 Implemented patterns:
 
-* [Mixins](docs/mixins.md)
+* [Hooks](docs/hooks.md)
 * [Higher order components](docs/higher-order.md) (curried so also usable as ES7 decorators)
+* [Mixins](docs/mixins.md)
 
 ## Summary
 
@@ -51,13 +52,17 @@ This is necessary so that isomorphism can remain an enjoyable stroll in the park
 
 ## Patterns
 
-### Mixins
+### Hooks
 
-[Dedicated documentation](docs/mixins.md)
+[Dedicated documentation](docs/hooks.md)
 
 ### Higher Order Components
 
 [Dedicated documentation](docs/higher-order.md)
+
+### Mixins
+
+[Dedicated documentation](docs/mixins.md)
 
 ## Common pitfalls
 

--- a/docs/hooks.md
+++ b/docs/hooks.md
@@ -1,0 +1,291 @@
+# Hooks
+
+In this example, we'll build a simplistic React app showing a list of colors to see how one could integrate **Baobab** with React by using hooks.
+
+### Summary
+
+* [Hooks](#hooks)
+* [Summary](#summary)
+* [Creating the app's state](#creating-the-apps-state)
+* [Rooting our top-level component](#rooting-our-top-level-component)
+* [Branching our list](#branching-our-list)
+* [Actions](#actions)
+* [Dynamically set the list's path using props](#dynamically-set-the-lists-path-using-props)
+* [Clever vs. dumb components](#clever-vs-dumb-components)
+
+### Creating the app's state
+
+Let's create a **Baobab** tree to store our colors' list:
+
+*state.js*
+
+```js
+import Baobab from 'baobab';
+
+const tree = new Baobab({
+  colors: ['yellow', 'blue', 'orange']
+});
+
+export default tree;
+```
+
+### Rooting our top-level component
+
+Now that the tree is created, we should bind our React app to it by "rooting" our top-level component.
+
+Under the hood, this component will simply propagate the tree to its descendants using React's [Context](https://reactjs.org/docs/context.html) so that "branched" component may subscribe to updates of parts of the tree afterwards.
+
+*main.jsx*
+
+```jsx
+import React, {Component} from 'react';
+import {render} from 'react-dom';
+import {useRoot} from 'baobab-react/hooks';
+import tree from './state';
+
+// We will write this component later
+import List from './list.jsx';
+
+// Creating our top-level component
+const App = function({tree}) {
+  // useRoot takes the baobab tree and provides a component bound to the tree
+  const Root = useRoot(tree);
+  return (
+    <Root>
+      <List />
+    <Root>
+  );
+}
+
+// Rendering the app
+render(<App tree={tree} />, document.querySelector('#mount'));
+```
+
+### Branching our list
+
+Now that we have "rooted" our top-level `App` component, let's create the component displaying our colors' list and branch it to the tree's data.
+
+*list.jsx*
+
+```jsx
+import React, {Component} from 'react';
+import {useBranch} from 'baobab-react/hooks';
+
+const List = function() {
+  // branch by mapping the desired data to cursors
+  const {colors} = useBranch({
+    colors: ['colors']
+  });
+
+  function renderItem(color) {
+    return <li key={color}>{color}</li>;
+  }
+
+  return <ul>{colors.map(renderItem)}</ul>;
+}
+
+export default List;
+```
+
+Our app would now render something of the kind:
+
+```html
+<div>
+  <ul>
+    <li>yellow</li>
+    <li>blue</li>
+    <li>orange</li>
+  </ul>
+</div>
+```
+
+But let's add a color to the list:
+
+```js
+tree.push('colors', 'purple');
+```
+
+And the list component will automatically update and to render the following:
+
+```html
+<div>
+  <ul>
+    <li>yellow</li>
+    <li>blue</li>
+    <li>orange</li>
+    <li>purple</li>
+  </ul>
+</div>
+```
+
+Now you just need to add an action layer on top of that so that app's state can be updated and you've got yourself an atomic Flux!
+
+### Actions
+
+Here is what we are trying to achieve:
+
+```
+                                 ┌────────────────────┐
+                   ┌──────────── │    Central State   │ ◀───────────┐
+                   │             │    (Baobab tree)   │             │
+                   │             └────────────────────┘             │
+                Renders                                          Updates
+                   │                                                │
+                   │                                                │
+                   ▼                                                │
+        ┌────────────────────┐                           ┌────────────────────┐
+        │        View        │                           │       Actions      │
+        │ (React Components) │  ────────Triggers───────▶ │     (Functions)    │
+        └────────────────────┘                           └────────────────────┘
+```
+
+For the time being we only have a central state stored by a Baobab tree and a view layer composed of React components.
+
+What remains to be added is a way for the user to trigger actions and update the central state.
+
+To do so `baobab-react` proposes to create simple functions as actions:
+
+*actions.js*
+
+```js
+export function addColor(tree, color) {
+  tree.push('colors', color);
+}
+```
+
+Now let's add a simple button so that a user may add colors:
+
+*list.jsx*
+
+```jsx
+import React, {useState} from 'react';
+import {useBranch} from 'baobab-react/hooks';
+import * as actions from './actions';
+
+const List = function() {
+  const [inputColor, setColor] = useState(null);
+  // Subscribing to the relevant data in the tree
+  const {colors, dispatch} = useBranch({
+    colors: ['colors']
+  });
+
+  // Adding a color on click
+  const handleClick = () => {
+    // A dispatcher is available through `props.dispatch`
+    dispatch(
+      actions.addColor,
+      inputColor
+    );
+
+    // Resetting the input
+    setColor(null);
+  };
+
+  return (
+    <div>
+      <ul>{colors.map(renderItem)}</ul>
+      <input type="text"
+             value={this.state.inputColor}
+             onUpdate={e => setColor(e.target.value)} />
+      <button type="button" onClick={() => this.handleClick}>Add</button>
+    </div>
+  );
+};
+
+export default List;
+```
+
+### Dynamically set the list's path using props
+
+Sometimes, you might find yourself needing cursors paths changing along with your component's props.
+
+For instance, given the following state:
+
+*state.js*
+
+```js
+import Baobab from 'baobab';
+
+const tree = new Baobab({
+  colors: ['yellow', 'blue', 'orange'],
+  alternativeColors: ['purple', 'orange', 'black']
+});
+
+export default tree;
+```
+
+You might want to have a list rendering either one of the colors' lists.
+
+Fortunately, you can do so by passing a function taking both props and context of the components and returning a valid mapping:
+
+*list.jsx*
+
+```jsx
+import React, {Component} from 'react';
+import {useBranch} from 'baobab-react/hooks';
+
+const List = function(props) {
+  // Using a function so that your cursors' path can use the component's props etc.
+  const {colors} = useBranch({
+    colors: [props.alternative ? 'alternativeColors' : 'colors']
+  });
+
+  function renderItem(color) {
+    return <li key={color}>{color}</li>;
+  }
+
+  return <ul>{colors.map(renderItem)}</ul>;
+}
+
+export default List;
+```
+
+### Clever vs. dumb components
+
+Now you know everything to use a Baobab tree efficiently with React.
+
+However, the example app shown above is minimalist and should probably not be organized thusly in a real-life scenario.
+
+Indeed, whenever possible, one should try to separate "clever" components, that know about the tree's existence from "dumb" components, completely oblivious of it.
+
+Knowing when to branch/wrap a component and let some components ignore the existence of the tree is the key to a maintainable and scalable application.
+
+**Example**
+
+*Clever component*
+
+This component does know that a tree provides him with data.
+
+```js
+import React, {Component} from 'react';
+import {useBranch} from 'baobab-react/hooks';
+import List from './list.jsx';
+
+class ListWrapper extends Component {
+  const {colors} = useBranch({
+    colors: ['colors']
+  });
+  return <List items={this.props.colors} />;
+}
+
+export default ListWrapper;
+```
+
+*Dumb component*
+
+This component should stay unaware of the tree so it can remain generic and be used elsewhere easily.
+
+```js
+import React, {Component} from 'react';
+
+export default class List extends Component {
+  render() {
+
+    function renderItem(value) {
+      return <li key={value}>{value}</li>;
+    }
+
+    return <ul>{this.props.items.map(renderItem)}</ul>;
+  }
+}
+```

--- a/docs/hooks.md
+++ b/docs/hooks.md
@@ -47,9 +47,9 @@ import tree from './state';
 import List from './list.jsx';
 
 // Creating our top-level component
-const App = function({tree}) {
+const App = function({store}) {
   // useRoot takes the baobab tree and provides a component bound to the tree
-  const Root = useRoot(tree);
+  const Root = useRoot(store);
   return (
     <Root>
       <List />
@@ -58,7 +58,7 @@ const App = function({tree}) {
 }
 
 // Rendering the app
-render(<App tree={tree} />, document.querySelector('#mount'));
+render(<App store={tree} />, document.querySelector('#mount'));
 ```
 
 ### Branching our list

--- a/hooks.js
+++ b/hooks.js
@@ -1,0 +1,3 @@
+var wrappers = require('./dist-modules/hooks.js');
+exports.useRoot = wrappers.useRoot;
+exports.useBranch = wrappers.useBranch;

--- a/index.js
+++ b/index.js
@@ -1,5 +1,6 @@
 module.exports = {
   higherOrder: require('./higher-order.js'),
   mixins: require('./mixins.js'),
+  hooks: require('./hooks.js'),
   PropTypes: require('./dist-modules/utils/prop-types.js').default,
 };

--- a/package.json
+++ b/package.json
@@ -39,14 +39,15 @@
     "babelify": "^7.2.0",
     "baobab": "^2.3.3",
     "browserify": "^13.0.0",
-    "enzyme": "^2.0.0",
+    "create-react-class": "^15.6.3",
+    "enzyme": "^3.9.0",
+    "enzyme-adapter-react-16": "^1.11.2",
     "eslint": "^2.2.0",
     "jsdom": "^8.1.0",
     "mocha": "^2.2.4",
-    "react": "^15.5.0",
-    "react-dom": "^15.5.4",
-    "react-test-renderer": "^15.5.4",
-    "create-react-class": "^15.5.3"
+    "react": "^16.8.6",
+    "react-dom": "^16.8.6",
+    "react-test-renderer": "^16.8.6"
   },
   "eslintConfig": {
     "extends": [

--- a/package.json
+++ b/package.json
@@ -60,5 +60,8 @@
         "jsx": true
       }
     }
+  },
+  "dependencies": {
+    "deep-equal": "^1.0.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -7,9 +7,10 @@
     "prepublish": "babel ./src --out-dir dist-modules",
     "lint": "eslint ./src",
     "test": "mocha -R spec --require ./test/setup.js --compilers jsx:babel-register ./test",
-    "build": "npm run build-mixins && npm run build-higher-order",
+    "build": "npm run build-mixins && npm run build-higher-order && npm run build-hooks",
     "build-mixins": "mkdir -p build && browserify -x baobab -t babelify ./src/mixins.js -o build/mixins.js",
-    "build-higher-order": "mkdir -p build && browserify -x baobab -x react -t babelify ./src/higher-order.js -o build/higher-order.js"
+    "build-higher-order": "mkdir -p build && browserify -x baobab -x react -t babelify ./src/higher-order.js -o build/higher-order.js",
+    "build-hooks": "mkdir -p build && browserify -x baobab -x react -t babelify ./src/hooks.js -o build/hooks.js"
   },
   "repository": {
     "type": "git",

--- a/src/context.js
+++ b/src/context.js
@@ -1,0 +1,4 @@
+import React from 'react';
+
+// context shared between higher-order and hooks
+export default React.createContext();

--- a/src/higher-order.js
+++ b/src/higher-order.js
@@ -8,11 +8,10 @@ import React from 'react';
 import Baobab from 'baobab';
 import {curry, isBaobabTree, solveMapping} from './utils/helpers';
 import deepEqual from 'deep-equal';
+import BaobabContext from './context';
 
 const makeError = Baobab.helpers.makeError,
       isPlainObject = Baobab.type.object;
-
-const BaobabContext = React.createContext();
 
 /**
  * Helpers
@@ -163,4 +162,4 @@ function branch(cursors, Component) {
 const curriedRoot = curry(root, 2),
       curriedBranch = curry(branch, 2);
 
-export {curriedRoot as root, curriedBranch as branch, BaobabContext as Context};
+export {curriedRoot as root, curriedBranch as branch};

--- a/src/hooks.js
+++ b/src/hooks.js
@@ -54,7 +54,9 @@ export function useBranch(cursors) {
 
   const [state, setState] = useState(() => {
     const mapping = typeof cursors === 'function' ? cursors(context) : cursors;
-    return context.tree.project(mapping);
+    const obj = context.tree.project(mapping);
+    obj.dispatch = (fn, ...args) => fn(context.tree, ...args);
+    return obj;
   });
 
   useEffect(() => {
@@ -62,7 +64,9 @@ export function useBranch(cursors) {
     const watcher = context.tree.watch(mapping);
 
     watcher.on('update', () => {
-      setState(watcher.get());
+      const obj = watcher.get();
+      obj.dispatch = (fn, ...args) => fn(context.tree, ...args);
+      setState(obj);
     });
 
     return () => watcher.release();

--- a/src/hooks.js
+++ b/src/hooks.js
@@ -1,27 +1,55 @@
-import {useContext, useState, useEffect} from 'react';
-import {Context} from './higher-order';
+import React, {useContext, useState, useEffect} from 'react';
 import {isBaobabTree} from './utils/helpers';
 import Baobab from 'baobab';
+import BaobabContext from './context';
 
 const makeError = Baobab.helpers.makeError,
       isPlainObject = Baobab.type.object;
 
 function invalidMapping(name, mapping) {
   throw makeError(
-    'baobab-react/useBranch: given cursors mapping is invalid (check the "' + name + '" component).',
+    'baobab-react/hooks.useBranch: given cursors mapping is invalid (check the "' + name + '" component).',
     {mapping}
   );
+}
+
+export function useRoot(tree) {
+  if (!isBaobabTree(tree))
+    throw makeError(
+      'baobab-react/hooks.useRoot: given tree is not a Baobab.',
+      {target: tree}
+    );
+
+  const [state, setState] = useState(() => {
+    return ({children}) => {
+      return React.createElement(BaobabContext.Provider, {
+        value: {tree}
+      }, children);
+    };
+  });
+
+  useEffect(() => {
+    setState(() => {
+      return ({children}) => {
+        return React.createElement(BaobabContext.Provider, {
+          value: {tree}
+        }, children);
+      };
+   });
+  }, [tree]);
+
+  return state;
 }
 
 export function useBranch(cursors) {
   if (!isPlainObject(cursors) && typeof cursors !== 'function')
     invalidMapping(name, cursors);
 
-  const context = useContext(Context);
+  const context = useContext(BaobabContext);
 
   if (!context || !isBaobabTree(context.tree))
     throw makeError(
-      'baobab-react/useBranch: tree is not available.'
+      'baobab-react/hooks.useBranch: tree is not available.'
     );
 
   const [state, setState] = useState(() => {

--- a/src/useBranch.js
+++ b/src/useBranch.js
@@ -1,0 +1,44 @@
+import {useContext, useState, useEffect} from 'react';
+import {Context} from './higher-order';
+import {isBaobabTree} from './utils/helpers';
+import Baobab from 'baobab';
+
+const makeError = Baobab.helpers.makeError,
+      isPlainObject = Baobab.type.object;
+
+function invalidMapping(name, mapping) {
+  throw makeError(
+    'baobab-react/useBranch: given cursors mapping is invalid (check the "' + name + '" component).',
+    {mapping}
+  );
+}
+
+export function useBranch(cursors) {
+  if (!isPlainObject(cursors) && typeof cursors !== 'function')
+    invalidMapping(name, cursors);
+
+  const context = useContext(Context);
+
+  if (!context || !isBaobabTree(context.tree))
+    throw makeError(
+      'baobab-react/useBranch: tree is not available.'
+    );
+
+  const [state, setState] = useState(() => {
+    const mapping = typeof cursors === 'function' ? cursors(context) : cursors;
+    return context.tree.project(mapping);
+  });
+
+  useEffect(() => {
+    const mapping = typeof cursors === 'function' ? cursors(context) : cursors;
+    const watcher = context.tree.watch(mapping);
+
+    watcher.on('update', () => {
+      setState(watcher.get());
+    });
+
+    return () => watcher.release();
+  }, [cursors]);
+
+  return state;
+}

--- a/test/higher-order.jsx
+++ b/test/higher-order.jsx
@@ -5,10 +5,12 @@
  */
 import assert from 'assert';
 import React, {Component} from 'react';
-import {mount} from 'enzyme';
+import enzyme, {mount} from 'enzyme';
 import Baobab from 'baobab';
-import {root, branch} from '../src/higher-order';
-import PropTypes from '../src/utils/prop-types';
+import {root, branch, Context} from '../src/higher-order';
+import Adapter from 'enzyme-adapter-react-16';
+ 
+enzyme.configure({ adapter: new Adapter() });
 
 /**
  * Components.
@@ -90,9 +92,7 @@ describe('Higher Order', function() {
         }
       }
 
-      Child.contextTypes = {
-        tree: PropTypes.baobab
-      };
+      Child.contextType = Context;
 
       const wrapper = mount(<Root tree={tree}><Child /></Root>);
 
@@ -110,7 +110,7 @@ describe('Higher Order', function() {
 
       assert.throws(function() {
         mount(<BranchedChild />);
-      }, /Baobab/);
+      }, /baobab-react/);
     });
   });
 

--- a/test/higher-order.jsx
+++ b/test/higher-order.jsx
@@ -7,10 +7,11 @@ import assert from 'assert';
 import React, {Component} from 'react';
 import enzyme, {mount} from 'enzyme';
 import Baobab from 'baobab';
-import {root, branch, Context} from '../src/higher-order';
+import BaobabContext from '../src/context';
+import {root, branch} from '../src/higher-order';
 import Adapter from 'enzyme-adapter-react-16';
  
-enzyme.configure({ adapter: new Adapter() });
+enzyme.configure({adapter: new Adapter()});
 
 /**
  * Components.
@@ -92,7 +93,7 @@ describe('Higher Order', function() {
         }
       }
 
-      Child.contextType = Context;
+      Child.contextType = BaobabContext;
 
       const wrapper = mount(<Root tree={tree}><Child /></Root>);
 

--- a/test/hook.jsx
+++ b/test/hook.jsx
@@ -1,0 +1,188 @@
+/**
+ * Baobab-React Mixins Unit Tests
+ * ===============================
+ *
+ */
+import assert from 'assert';
+import React, {Component} from 'react';
+import enzyme, {mount} from 'enzyme';
+import Baobab from 'baobab';
+import {root} from '../src/higher-order';
+import {useBranch} from '../src/useBranch';
+import Adapter from 'enzyme-adapter-react-16';
+ 
+enzyme.configure({ adapter: new Adapter() });
+
+/**
+ * Components.
+ */
+class DummyRoot extends Component {
+  render() {
+    return <div />;
+  }
+}
+
+class BasicRoot extends Component {
+  render() {
+    return (
+      <div>
+        {this.props.children}
+      </div>
+    );
+  }
+}
+
+/**
+ * Test suite.
+ */
+describe('Hook', function() {
+
+  describe('api', function() {
+    it('hook should throw an error if the passed argument is not valid.', function() {
+      const tree = new Baobab({name: 'John'}, {asynchronous: false});
+
+      const Root = root(tree, BasicRoot);
+
+      const Child = () => {
+        const data = useBranch();
+        return <span>Hello {data.name}</span>;
+      }
+
+      assert.throws(() => {
+        mount(<Root><Child /></Root>);
+      }, /baobab-react/);
+    });
+  });
+
+  describe('context', function() {
+    it('the tree should be propagated through context.', function() {
+      const tree = new Baobab({path: ['name'], name: 'John'}, {asynchronous: false});
+
+      const Root = root(tree, BasicRoot);
+
+      const Child = () => {
+        const data = useBranch(context => ({
+            name: context.tree.get('path'),
+        }));
+        return <span>Hello {data.name}</span>;
+      }
+
+      const wrapper = mount(<Root tree={tree}><Child /></Root>);
+
+      assert.strictEqual(wrapper.text(), 'Hello John');
+    });
+
+    it('should fail if the tree is not passed through context.', function() {
+      const Child = () => {
+        const data = useBranch({name: ['name']});
+        return <span>Hello John</span>;
+      }
+
+      assert.throws(function() {
+        mount(<Child />);
+      }, /baobab-react/);
+    });
+  });
+
+  describe('binding', function() {
+    it('should be possible to bind several cursors to a component.', function() {
+      const tree = new Baobab({name: 'John', surname: 'Talbot'}, {asynchronous: false});
+
+      const Child = () => {
+        const data = useBranch({
+          name: ['name'],
+          surname: ['surname']
+        });
+        return (
+          <span>
+            Hello {data.name} {data.surname}
+          </span>
+        );
+      }
+
+      const Root = root(tree, BasicRoot);
+
+      const wrapper = mount(<Root tree={tree}><Child /></Root>);
+
+      assert.strictEqual(wrapper.text(), 'Hello John Talbot');
+    });
+
+    it('should be possible to register paths using typical Baobab polymorphisms.', function() {
+      const tree = new Baobab({name: 'John', surname: 'Talbot'}, {asynchronous: false});
+
+      const Child = () => {
+        const data = useBranch({
+          name: 'name',
+          surname: 'surname'
+        });
+        return (
+          <span>
+            Hello {data.name} {data.surname}
+          </span>
+        );
+      }
+
+      const Root = root(tree, BasicRoot);
+
+      const wrapper = mount(<Root><Child /></Root>);
+
+      assert.strictEqual(wrapper.text(), 'Hello John Talbot');
+    });
+
+    it('bound components should update along with the cursor.', function(done) {
+      const tree = new Baobab({name: 'John', surname: 'Talbot'}, {asynchronous: false});
+
+      const Child = () => {
+        const data = useBranch({
+          name: 'name',
+          surname: 'surname'
+        });
+        return (
+          <span>
+            Hello {data.name} {data.surname}
+          </span>
+        );
+      }
+
+      const Root = root(tree, BasicRoot);
+
+      const wrapper = mount(<Root tree={tree}><Child /></Root>);
+
+      tree.set('surname', 'the Third');
+
+      setTimeout(() => {
+        assert.strictEqual(wrapper.text(), 'Hello John the Third');
+        done();
+      }, 50);
+    });
+
+    it('should be possible to set cursors with a function.', function(done) {
+      const tree = new Baobab({name: 'John', surname: 'Talbot'}, {asynchronous: false});
+
+      const Child = props => {
+        const data = useBranch(() => {
+          return {
+            name: ['name'],
+            surname: props.path
+          };
+        });
+        return (
+          <span>
+            Hello {data.name} {data.surname}
+          </span>
+        );
+      }
+
+      const Root = root(tree, BasicRoot);
+
+      const wrapper = mount(<Root><Child path={['surname']}/></Root>);
+
+      tree.set('surname', 'the Third');
+
+      setTimeout(() => {
+        assert.strictEqual(wrapper.text(), 'Hello John the Third');
+        done();
+      }, 50);
+    });
+  });
+});

--- a/test/hook.jsx
+++ b/test/hook.jsx
@@ -172,4 +172,33 @@ describe('Hook', function() {
       }, 50);
     });
   });
+
+  describe('actions', function() {
+    it('should be possible to dispatch actions.', function() {
+      const tree = new Baobab({counter: 0}, {asynchronous: false});
+
+      const inc = function(state, by = 1) {
+        state.apply('counter', nb => nb + by);
+      };
+
+      const Counter = function() {
+        const {counter, dispatch} = useBranch({counter: 'counter'});
+
+        return (
+          <span onClick={() => dispatch(inc)}
+                onChange={() => dispatch(inc, 2)}>
+            Counter: {counter}
+          </span>
+        );
+      };
+
+      const wrapper = mount(<BasicRoot tree={tree}><Counter /></BasicRoot>);
+
+      assert.strictEqual(wrapper.text(), 'Counter: 0');
+      wrapper.find('span').simulate('click');
+      assert.strictEqual(wrapper.text(), 'Counter: 1');
+      wrapper.find('span').simulate('change');
+      assert.strictEqual(wrapper.text(), 'Counter: 3');
+    });
+  });
 });

--- a/test/hook.jsx
+++ b/test/hook.jsx
@@ -4,44 +4,41 @@
  *
  */
 import assert from 'assert';
-import React, {Component} from 'react';
+import React from 'react';
 import enzyme, {mount} from 'enzyme';
 import Baobab from 'baobab';
-import {root} from '../src/higher-order';
-import {useBranch} from '../src/useBranch';
+import {useRoot, useBranch} from '../src/hooks';
 import Adapter from 'enzyme-adapter-react-16';
  
-enzyme.configure({ adapter: new Adapter() });
+enzyme.configure({adapter: new Adapter()});
 
 /**
  * Components.
  */
-class DummyRoot extends Component {
-  render() {
-    return <div />;
-  }
-}
-
-class BasicRoot extends Component {
-  render() {
-    return (
+const BasicRoot = function({tree, children}) {
+  const Root = useRoot(tree);
+  return (
+    <Root>
       <div>
-        {this.props.children}
+        {children}
       </div>
-    );
-  }
+    </Root>
+  );
 }
 
 /**
  * Test suite.
  */
 describe('Hook', function() {
-
   describe('api', function() {
-    it('hook should throw an error if the passed argument is not valid.', function() {
+    it('root should throw an error if the passed argument is not a tree.', function() {
+      assert.throws(function() {
+        mount(<BasicRoot />);
+      }, /baobab-react/);
+    });
+    
+    it('branch should throw an error if the passed argument is not valid.', function() {
       const tree = new Baobab({name: 'John'}, {asynchronous: false});
-
-      const Root = root(tree, BasicRoot);
 
       const Child = () => {
         const data = useBranch();
@@ -49,7 +46,7 @@ describe('Hook', function() {
       }
 
       assert.throws(() => {
-        mount(<Root><Child /></Root>);
+        mount(<BasicRoot tree={tree}><Child /></BasicRoot>);
       }, /baobab-react/);
     });
   });
@@ -58,8 +55,6 @@ describe('Hook', function() {
     it('the tree should be propagated through context.', function() {
       const tree = new Baobab({path: ['name'], name: 'John'}, {asynchronous: false});
 
-      const Root = root(tree, BasicRoot);
-
       const Child = () => {
         const data = useBranch(context => ({
             name: context.tree.get('path'),
@@ -67,7 +62,7 @@ describe('Hook', function() {
         return <span>Hello {data.name}</span>;
       }
 
-      const wrapper = mount(<Root tree={tree}><Child /></Root>);
+      const wrapper = mount(<BasicRoot tree={tree}><Child /></BasicRoot>);
 
       assert.strictEqual(wrapper.text(), 'Hello John');
     });
@@ -100,9 +95,7 @@ describe('Hook', function() {
         );
       }
 
-      const Root = root(tree, BasicRoot);
-
-      const wrapper = mount(<Root tree={tree}><Child /></Root>);
+      const wrapper = mount(<BasicRoot tree={tree}><Child /></BasicRoot>);
 
       assert.strictEqual(wrapper.text(), 'Hello John Talbot');
     });
@@ -122,9 +115,7 @@ describe('Hook', function() {
         );
       }
 
-      const Root = root(tree, BasicRoot);
-
-      const wrapper = mount(<Root><Child /></Root>);
+      const wrapper = mount(<BasicRoot tree={tree}><Child /></BasicRoot>);
 
       assert.strictEqual(wrapper.text(), 'Hello John Talbot');
     });
@@ -144,9 +135,7 @@ describe('Hook', function() {
         );
       }
 
-      const Root = root(tree, BasicRoot);
-
-      const wrapper = mount(<Root tree={tree}><Child /></Root>);
+      const wrapper = mount(<BasicRoot tree={tree}><Child /></BasicRoot>);
 
       tree.set('surname', 'the Third');
 
@@ -173,9 +162,7 @@ describe('Hook', function() {
         );
       }
 
-      const Root = root(tree, BasicRoot);
-
-      const wrapper = mount(<Root><Child path={['surname']}/></Root>);
+      const wrapper = mount(<BasicRoot tree={tree}><Child path={['surname']}/></BasicRoot>);
 
       tree.set('surname', 'the Third');
 


### PR DESCRIPTION
First steps of updating the library to remove legacy `getChildContext` API

Next steps:
- [x] move hoc branch `componentWillMount` logic to the constructor
- [x] replace `componentWillReceiveProps` with `componentDidUpdate`
- [x] create a `useBranch` hook
- [ ] ~~remove mixins~~

@Yomguithereal does this sound like a good plan?