### PR TITLE
Updating BranchedComponent state on componentDidMount.

### DIFF
--- a/src/higher-order.js
+++ b/src/higher-order.js
@@ -110,6 +110,7 @@ function branch(cursors, Component) {
           this.setState(this.watcher.get());
       };
 
+      handler();
       this.watcher.on('update', handler);
     }
 


### PR DESCRIPTION
This is a fix for a nasty bug we encountered as a result of the version change from 3.0.0 to 4.0.0.

In 3.0.0, the watcher update handler was registered in `componentWillMount`.

In 4.0.0, the watcher update handler is registered in `componentDidMount`.

However, the `branch` HOC will only fire `componentDidMount` after the wrapped component fires `componentDidMount`. This means that any updates to the tree resulting from the wrapped component's `componentDidMount` function are not reflected in the wrapped component's props.

In this branch, the watcher update handler is fired when the `branch` HOC mounts in order to catch any tree updates that may have taken place after the wrapped component mounts, but before the `branch` HOC mounts.